### PR TITLE
feat: add systemd to handle process execution and failures

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -56,3 +56,5 @@ executable(
   ],
   install: true,
 )
+
+install_data('sway-audio-idle-inhibit.service', install_dir : '/usr/lib/systemd/user' )

--- a/sway-audio-idle-inhibit.service
+++ b/sway-audio-idle-inhibit.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Prevents system from idling when there's an active audio source or sink
+
+BindsTo=graphical-session.target
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+ExecStart=/usr/bin/sway-audio-idle-inhibit
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Currently, in certain scenarios, unreproducable scenarios, `sway-audio-idle-inhibit` crashes due to segfaults. This PR makes makes the `sway-audio-idle-inhibit` a systemd service to offload the responsibility of process startup and failure handling.